### PR TITLE
changed the name of the Debian samba service

### DIFF
--- a/samba/map.jinja
+++ b/samba/map.jinja
@@ -2,7 +2,7 @@
     'Debian': {
         'server': 'samba',
         'client': 'samba-client',
-        'service': 'smbd',
+        'service': 'samba',
         'config': '/etc/samba/smb.conf',
         'config_src': 'salt://samba/files/smb.conf',
     },


### PR DESCRIPTION
The name of the samba service on Debian Wheezy is "samba", not "smbd".
