### PR TITLE
Special-cased the Ubuntu samba service name

### DIFF
--- a/samba/map.jinja
+++ b/samba/map.jinja
@@ -13,4 +13,8 @@
         'config': '/etc/samba/smb.conf',
         'config_src': 'salt://samba/files/smb.conf',
     },
-}, merge=salt['pillar.get']('samba:lookup')) %}
+}, merge=salt['grains.filter_by']({
+    'Ubuntu': {
+        'service': 'smbd',
+    },
+}, grain='os', merge=salt['pillar.get']('samba:lookup'))) %}


### PR DESCRIPTION
While Debian uses `samba` as the service name, Ubuntu (which is in the Debian os_family) uses `smbd`.

I updated the `map.jinja` to reflect this.
