### PR TITLE
Fixing RedHat service name

### DIFF
--- a/samba/map.jinja
+++ b/samba/map.jinja
@@ -9,7 +9,7 @@
     'RedHat': {
         'server': 'samba',
         'client': 'samba',
-        'service': 'smbd',
+        'service': 'smb',
         'config': '/etc/samba/smb.conf',
         'config_src': 'salt://samba/files/smb.conf',
     },


### PR DESCRIPTION
In RedHat 5 and 6, the samba service name is smb.

RedHat 5: https://access.redhat.com/site/documentation/en-US/Red_Hat_Enterprise_Linux/5/html/Deployment_Guide/s1-samba-daemons.html

RedHat 6: https://access.redhat.com/site/documentation/en-US/Red_Hat_Enterprise_Linux/6/html/Deployment_Guide/ch-File_and_Print_Servers.html#s2-samba-daemons
