### PR TITLE
Fix service name to use on Debian depending on the precise release

### DIFF
--- a/samba/map.jinja
+++ b/samba/map.jinja
@@ -2,7 +2,13 @@
     'Debian': {
         'server': 'samba',
         'client': 'samba-client',
-        'service': 'samba',
+        'service': salt['grains.filter_by']({
+	    'lenny': 'samba',
+	    'squeeze': 'samba',
+	    'wheezy': 'samba',
+	    'jessie': 'smbd',
+	    'default': 'smbd',
+	}, grain='oscodename'),
         'config': '/etc/samba/smb.conf',
         'config_src': 'salt://samba/files/smb.conf',
     },


### PR DESCRIPTION
Starting with Jessie, the service is now managed as "smbd" and no longer
as "samba". Fixes github issue #12.

Note: I did not use the "default" keyword parameter of filter_by to ensure
some backwards compatibility.
