### PR TITLE
Configuration settings for generated config file

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -1,3 +1,7 @@
+samba_config:
+  section_order: [global, homes, printers]
+  include_skeleton: no
+
 samba_sections:
   global:
     workgroup: MYGROUP

--- a/samba/files/smb.conf
+++ b/samba/files/smb.conf
@@ -1,16 +1,30 @@
-{% set samba_sections = pillar.get('samba_sections', {}) %}
-#
-# This file is managed by salt. Manual changes risk being overwritten.
-# The contents of the original skeleton smb.conf are kept at the bottom
-# as a quick reference to the default option values.
-#
+{%- set samba_sections = pillar.get('samba_sections', {}) %}
+{%- set conf_generator_settings = pillar.get('samba_config', {}) %}
 
-{%- for section in samba_sections.keys() %}
+{%- macro config_section(section) %}
+{%- set options = samba_sections.get(section, {}) -%}
 [{{ section }}]
-    {%- for option, value in samba_sections.get(section, {}).items() %}
+    {%- for option, value in options.items() %}
     {{ option }} = {{ value }}
     {%- endfor %}
-{%- endfor%}
+{%- endmacro -%}
+
+#
+# This file is managed by salt. Manual changes risk being overwritten.
+# If so configured, the contents of the original skeleton smb.conf are stored
+# at the bottom as a quick reference to the default option values.
+#
+{%- set ordered_sections = conf_generator_settings.get('section_order', []) %}
+{%- for k in ordered_sections %}
+{{ config_section(k) }}
+{%- endfor -%}
+{%- for k in samba_sections.keys() %}
+    {%- if k not in ordered_sections %}
+{{ config_section(k) }}
+    {%- endif %}
+{%- endfor -%}
+
+{%- if conf_generator_settings.get('include_skeleton', True) %}
 
 # This is the main Samba configuration file. You should read the
 # smb.conf(5) manual page in order to understand the options listed
@@ -296,5 +310,4 @@
 ;   writable = yes
 ;   printable = no
 ;   create mask = 0765
-
-
+{%- endif %}


### PR DESCRIPTION
Added a way to strip out the skeleton from the generated samba configuration file, and a way to enforce a specific section ordering amongst the generated configuration sections.
