### PR TITLE
File modes with leading zero need to be quoted

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -25,21 +25,21 @@ samba_sections:
     writeable: yes
     valid users: @sharegroup
     force group: sharegroup
-    create mask: 0660
-    directory mask: 2770
+    create mask: '0660'
+    directory mask: '2770'
   user1share:
     comment: "user1 samba share"
     path: /usr/somewhere/private
     valid users: user1
-    create mode: 0660
-    directory mode: 0770
+    create mode: '0660'
+    directory mode: '0770'
     public: no
     writable: yes
     printable: no
 
 
 samba_users:
-  user1: 
+  user1:
     password: user1sambapassword
   user2:
     password: user2sambapassword


### PR DESCRIPTION
In example pillar.
To avoid yaml parse them as integers and evaluate as octal value.
https://docs.saltstack.com/en/latest/topics/troubleshooting/yaml_idiosyncrasies.html