### PR TITLE
Resolve issue #25 rendering error

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -27,7 +27,7 @@ samba_sections:
     comment: "This is a shared directory"
     browseable: yes
     writeable: yes
-    valid users: @sharegroup
+    valid users: '@sharegroup'
     force group: sharegroup
     create mask: '0660'
     directory mask: '2770'


### PR DESCRIPTION
This PR replaces `valid users: @sharegroup` with `valid users: '@sharegroup'` in pillar.example, to alleviate risk of rendering error. Fixes #25