### PR TITLE
Add defaults, osmapping yaml for more modular formula

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -1,49 +1,49 @@
-samba_config:
-  section_order: [global, homes, printers]
-  include_skeleton: no
 
-samba_sections:
-  global:
-    workgroup: MYGROUP
-    server string: "Samba Server"
-    printcap name: /etc/printcap
-    load printers: yes
-    log file: "/var/log/samba/%m.log"
-    max log size: 50
-    security: user
-    dns proxy: no
-  homes:
-    comment: "Home Directories"
-    browseable: no
-    writeable: yes
-  printers:
-    comment: "All Printers"
-    path: /var/spool/samba
-    browseable: no
-    guest ok: no
-    writeable: no
-    printable: yes
-  sharename:
-    comment: "This is a shared directory"
-    browseable: yes
-    writeable: yes
-    valid users: @sharegroup
-    force group: sharegroup
-    create mask: '0660'
-    directory mask: '2770'
-  user1share:
-    comment: "user1 samba share"
-    path: /usr/somewhere/private
-    valid users: user1
-    create mode: '0660'
-    directory mode: '0770'
-    public: no
-    writable: yes
-    printable: no
+samba:
+  conf:
+    render:
+      section_order: ['global', 'homes', 'printers', 'sharename', 'user1share']
+    sections:
+      global:
+        workgroup: MYGROUP
+        server string: "Samba Server"
+        printcap name: /etc/printcap
+        load printers: yes
+        log file: "/var/log/samba/%m.log"
+        max log size: 50
+        security: user
+        dns proxy: no
+      homes:
+        comment: "Home Directories"
+        browseable: no
+        writeable: yes
+      printers:
+        comment: "All Printers"
+        path: /var/spool/samba
+        browseable: no
+        guest ok: no
+        writeable: no
+        printable: yes
+      sharename:
+        comment: "This is a shared directory"
+        browseable: yes
+        writeable: yes
+        valid users: '@sharegroup'
+        force group: sharegroup
+        create mask: '0660'
+        directory mask: '2770'
+      user1share:
+        comment: "user1 samba share"
+        path: /home/user1
+        valid users: user1
+        create mode: '0660'
+        directory mode: '0770'
+        public: no
+        writable: yes
+        printable: no
+  users:
+    user1:
+      password: user1sambapassword
+    user2:
+      password: user2sambapassword
 
-
-samba_users:
-  user1:
-    password: user1sambapassword
-  user2:
-    password: user2sambapassword

--- a/samba/defaults.yaml
+++ b/samba/defaults.yaml
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+# vim: ft=jinja
+
+# Default lookup dictionary
+samba:
+  server: samba
+  client: samba
+  service: smbd
+  config: /etc/samba/smb.conf
+  config_src: salt://samba/files/smb.conf
+
+  conf:
+    render:
+      section_order: ['global',]
+      include_skeleton: yes
+    sections:
+      global:
+

--- a/samba/defaults.yaml
+++ b/samba/defaults.yaml
@@ -11,8 +11,13 @@ samba:
 
   conf:
     render:
-      section_order: ['global',]
+      section_order: ['global']
       include_skeleton: yes
     sections:
       global:
 
+  users:
+
+  preinstall:
+    cmd:
+    osreleases: []

--- a/samba/files/smb.conf
+++ b/samba/files/smb.conf
@@ -1,5 +1,5 @@
-{%- set samba_sections = pillar.get('samba_sections', {}) %}
-{%- set conf_generator_settings = pillar.get('samba_config', {}) %}
+{%- set samba_sections = salt['pillar.get']('samba:conf:sections', {}) %}
+{%- set conf_generator_settings = salt['pillar.get']('samba:conf:render', {}) %}
 
 {%- macro config_section(section) %}
 {%- set options = samba_sections.get(section, {}) -%}

--- a/samba/init.sls
+++ b/samba/init.sls
@@ -1,5 +1,7 @@
 {% from "samba/map.jinja" import samba with context %}
 
+  {% if grains.os not in ('MacOS', 'Windows',) %}
+
 samba:
   pkg.installed:
     - name: {{ samba.server }}
@@ -8,3 +10,5 @@ samba:
     - enable: True
     - require:
       - pkg: samba
+
+  {% endif %}

--- a/samba/init.sls
+++ b/samba/init.sls
@@ -1,6 +1,17 @@
 {% from "samba/map.jinja" import samba with context %}
 
-  {% if grains.os not in ('MacOS', 'Windows',) %}
+{% if grains.os not in ('MacOS', 'Windows',) %}
+
+  {% if samba.preinstall.cmd %}
+    {% if grains.osmajorrelease in samba.preinstall.osreleases %}
+
+samba_preinstall_cmd:
+  cmd.run:
+    - name: {{ samba.preinstall.cmd }}
+    - require_in: pkg.samba
+
+    {% endif %}
+  {% endif %}
 
 samba:
   pkg.installed:
@@ -11,4 +22,4 @@ samba:
     - require:
       - pkg: samba
 
-  {% endif %}
+{% endif %}

--- a/samba/map.jinja
+++ b/samba/map.jinja
@@ -23,6 +23,10 @@
      'Suse':{
           'service': 'smb',
           'client' : 'samba-client',
+          'preinstall': {
+               'cmd': 'zypper --non-interactive dup --no-allow-vendor-change',
+               'osreleases': [42],
+             },
      },
      'Arch': {
          'client': 'smbclient',

--- a/samba/map.jinja
+++ b/samba/map.jinja
@@ -1,47 +1,51 @@
-{% set samba = salt['grains.filter_by']({
+# -* coding: utf-8 -*-
+# vim: ft=jinja
+# OS family parameters overriding defaults
+
+{## start with defaults from defaults.yaml ##}
+{% import_yaml "samba/defaults.yaml" as defaults %}
+
+{% set osmap = salt['grains.filter_by']({
     'Debian': {
-        'server': 'samba',
         'client': 'samba-client',
         'service': salt['grains.filter_by']({
 	    'lenny': 'samba',
 	    'squeeze': 'samba',
 	    'wheezy': 'samba',
-	    'jessie': 'smbd',
-	    'default': 'smbd',
-	}, grain='oscodename'),
-        'config': '/etc/samba/smb.conf',
-        'config_src': 'salt://samba/files/smb.conf',
+	}, grain='oscodename', default='lenny'),
+     },
+     'RedHat': {
+         'service': 'smb',
+     },
+     'CentOS': {
+         'service': 'smb',
+     },
+     'Suse':{
+          'service': 'smb',
+          'client' : 'samba-client',
+     },
+     'Arch': {
+         'client': 'smbclient',
+     },
+     'FreeBSD': {
+         'server': 'samba44',
+         'client': 'samba44',
+         'service': 'samba_server',
+         'config': '/usr/local/etc/smb4.conf',
+     },
+     'MacOS': {
+   },
+ }, grain='os_family', merge=salt['grains.filter_by']({
+     'Ubuntu': {
+        'client': 'smbclient',
+        'service': salt['grains.filter_by']({
+            'xenial': 'smbd',
+            'trusty': 'samba',
+        }, grain='oscodename', default='xenial'),
     },
-    'RedHat': {
-        'server': 'samba',
-        'client': 'samba',
-        'service': 'smb',
-        'config': '/etc/samba/smb.conf',
-        'config_src': 'salt://samba/files/smb.conf',
-    },
-    'CentOS': {
-        'server': 'samba',
-        'client': 'samba',
-        'service': 'smb',
-        'config': '/etc/samba/smb.conf',
-        'config_src': 'salt://samba/files/smb.conf',
-    },
-    'Arch': {
-        'server': 'samba',
-        'client': 'samba',
-        'service': 'smbd',
-        'config': '/etc/samba/smb.conf',
-        'config_src': 'salt://samba/files/smb.conf',
-    },
-    'FreeBSD': {
-        'server': 'samba44',
-        'client': 'samba44',
-        'service': 'samba_server',
-        'config': '/usr/local/etc/smb4.conf',
-        'config_src': 'salt://samba/files/smb.conf',
-    },
-}, merge=salt['grains.filter_by']({
-    'Ubuntu': {
-        'service': 'smbd',
-    },
-}, grain='os', merge=salt['pillar.get']('samba:lookup'))) %}
+}, grain='os', merge=salt['pillar.get']('samba')), base='samba') %}
+
+# Merge osmap onto default settings before merging pillars
+{% do defaults.samba.update(osmap) %}
+{% set samba = salt['pillar.get']( 'samba', default=defaults.samba, merge=True) %}
+

--- a/samba/users.sls
+++ b/samba/users.sls
@@ -1,9 +1,9 @@
-{% if grains['os_family']=='RedHat' %}
+{% if grains['os_family'] in ('RedHat', 'Suse', 'Debian') %}
 include:
   - samba.client
 {% endif %}
 
-{% for login,user in pillar.get('samba_users', {}).items() %}
+{% for login,user in salt['pillar.get']('samba:users', {}).items() %}
 {{ login }}:
   user.present:
     - fullname: {{ login }}


### PR DESCRIPTION
This pull request enhances the formula by introducing the more modular design.  Common defaults move to `defaults.yaml`, os mapping moves to `codenamemap.yaml` and `osmap.yaml`.   As a further enhancement the samba_config, samba_sections, and samba_users are moved under parent samba ID.

Changelog:
1. Introduce defaults.yaml for common defaults.
2. Use `map.jinja` pattern for OS mapping, promoted by community.
3. Add Suse support.

This PR resolves #23 and #25 issues and facilitates planned work on Winbind support (#22)

Verification logs:
[samba_arch.log.txt](https://github.com/saltstack-formulas/samba-formula/files/1376237/samba_arch.log.txt)
[samba_centos.log.txt](https://github.com/saltstack-formulas/samba-formula/files/1376238/samba_centos.log.txt)
[samba_suse.log.txt](https://github.com/saltstack-formulas/samba-formula/files/1376239/samba_suse.log.txt)
[samba_utuntu.log.txt](https://github.com/saltstack-formulas/samba-formula/files/1376240/samba_utuntu.log.txt)
