### PR TITLE
Winbind2: Update map.jinja for winbind/samba defaults

### DIFF
--- a/samba/defaults.yaml
+++ b/samba/defaults.yaml
@@ -7,8 +7,6 @@
 # Default lookup dictionary
 samba:
   server: samba
-  client: samba
-  service: smbd
   config: /etc/samba/smb.conf
   config_src: salt://samba/files/smb.conf
   root_group: root
@@ -43,7 +41,7 @@ samba:
         #idmap config shortdomainname:range: 500-40000
         #idmap config shortdomainname:schema_mode: rfc2307
         #idmap config shortdomainname:backend: ad
-        #idmap config *:range: 16777216-33554431
+        idmap config *:range: 16777216-33554431
         #idmap config *:backend: tdb
         #idmap domains: {{ default_realm }}
         #idmap config {{ default_realm }}:backend: rid
@@ -61,7 +59,7 @@ samba:
         winbind trusted domains only: no
         winbind nss info: rfc2307
         winbind refresh tickets: yes
-        winbind offline logon: yes
+        winbind offline logon: no
         winbind cache time: 10
         domain master: no
         local master: no

--- a/samba/defaults.yaml
+++ b/samba/defaults.yaml
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 # vim: ft=jinja
 
+{% set default_realm=salt['pillar.get']('samba:winbind:krb5_default_realm', 'EXAMPLE.COM')%}
+{% set default_workgroup=salt['pillar.get']('samba:conf:sections:global:workgroup', 'EXAMPLE')%}
+
 # Default lookup dictionary
 samba:
   server: samba
@@ -8,16 +11,119 @@ samba:
   service: smbd
   config: /etc/samba/smb.conf
   config_src: salt://samba/files/smb.conf
+  root_group: root
 
   conf:
     render:
-      section_order: ['global']
+      #### Inherit these as smb.conf defaults.
+      section_order: ['global', 'homes', 'printers', 'sharename',]
       include_skeleton: yes
     sections:
       global:
+        workgroup: {{ default_workgroup }}
+        server string: "Samba Server"
+        log file: "/var/log/samba/%m.log"
+        max log size: 50
+        dns proxy: no
+        load printers: yes
+        printing: cups
+        printcap name: cups
+        security: user
+      global_winbind_ad:
+        #### this gets merged if custom 'samba.winbind.krb5.default_realm'
+        #### pillar is found, otherwise its ignored.
+        realm: {{ default_realm }}
+        security: ADS
+        client signing: yes
+        client use spnego: yes
+        encrypt passwords: yes
+        idmap backend: lwopen
+        #idmap uid: 50-9999999999
+        #idmap gid: 50-9999999999
+        #idmap config shortdomainname:range: 500-40000
+        #idmap config shortdomainname:schema_mode: rfc2307
+        #idmap config shortdomainname:backend: ad
+        #idmap config *:range: 16777216-33554431
+        #idmap config *:backend: tdb
+        #idmap domains: {{ default_realm }}
+        #idmap config {{ default_realm }}:backend: rid
+        #idmap config {{ default_realm }}:base_rid: 0
+        #idmap config {{ default_realm }}:range: 20000 - 49999
+        #idmap uid: 10000-20000
+        #idmap gid: 10000-20000
+        kerberos method: secrets and keytab
+        template shell: /bin/bash
+        template homedir: /home/%U
+        winbind enum users: yes
+        winbind enum groups: yes
+        #winbind enable local accounts: yes ## depreciated??
+        winbind use default domain: yes
+        winbind trusted domains only: no
+        winbind nss info: rfc2307
+        winbind refresh tickets: yes
+        winbind offline logon: yes
+        winbind cache time: 10
+        domain master: no
+        local master: no
+        preferred master: no
+        #vfs objects: acl_xattr
+        #map acl inherit: true
+      homes:
+        comment: "Home Directories"
+        browseable: no
+        read only: No
+        inherit acls: No
+        writeable: yes
+      printers:
+        comment: "All Printers"
+        path: /var/lib/samba/drivers
+        browseable: no
+        guest ok: yes
+        writeable: no
+        printable: yes
+        #printer admin: root, '@ntadmins', '@smbprintadm'
+      sharename:
+        comment: "This is a shared directory"
+        browseable: yes
+        writeable: yes
+        valid users: '@sharegroup'
+        force group: sharegroup
+        create mask: '0660'
+        directory mask: '2770'
 
   users:
 
   preinstall:
     cmd:
     osreleases: []
+
+  winbind:
+    krb5_default_realm: {{ default_realm }}
+    joindomain: net ads join {{ default_realm }} #-U user
+
+    pam_winbind:
+      config: /etc/security/pam_winbind.conf
+      config_src: salt://samba/files/pam_winbind.conf
+      global:
+        debug: no
+        debug_state: no
+        cached_login: no
+        krb5_auth: yes
+        krb5_ccache_type:
+        require_membership_of:
+        warn_pwd_expire: 14
+        silent: no
+        mkhomedir: yes
+
+    pam_common_session:
+      regex: ['^(?!#).*(?<!#|\w)(session.*req.*pam_unix.so.*$)', r'\1\n\1\tpam_mkhomedir.so skel=/etc/skel/ umask=0077\n',]
+
+    nsswitch:
+      regex:
+       {% raw %}
+        - ['passwd', '^(?!#).*(?<!#|\w)(passwd.*:.*(files|compat))(?!.*winbind)(.*$)(?<!winbind)', '\1 winbind \3',]
+        - ['shadow', '^(?!#).*(?<!#|\w)(shadow.*:.*(files|compat))(?!.*winbind)(.*$)(?<!winbind)', '\1 winbind \3',]
+        - ['group', '^(?!#|net).*(?<!#|\w)(group.*:.*(files|compat))(?!.*winbind)(.*$)(?<!winbind)', '\1 winbind \3',]
+        - ['hostsMdns', '^(?!#).*(?<!#|\w)(host.*:.*files\s)(mdns4?_minimal.*\]\s*)(dns.*$)', '\1 \3',]
+        - ['hostsWins', '^(?!#).*(?<!#|\w)(host.*:.*files\s)(?!.*wins)(.*$)(?<!wins)', '\1wins\2',]
+       {% endraw %}

--- a/samba/map.jinja
+++ b/samba/map.jinja
@@ -2,10 +2,11 @@
 # vim: ft=jinja
 # OS family parameters overriding defaults
 
-{## start with defaults from defaults.yaml ##}
-{% import_yaml "samba/defaults.yaml" as defaults %}
-
-{% set osmap = salt['grains.filter_by']({
+{% set samba_osmap = salt['grains.filter_by']({
+    'default':{
+        'client': 'samba-client',
+        'service': 'smb',
+        },
     'Debian': {
         'client': 'samba-client',
         'service': salt['grains.filter_by']({
@@ -13,12 +14,6 @@
 	    'squeeze': 'samba',
 	    'wheezy': 'samba',
 	}, grain='oscodename', default='lenny'),
-     },
-     'RedHat': {
-         'service': 'smb',
-     },
-     'CentOS': {
-         'service': 'smb',
      },
      'Suse':{
           'service': 'smb',
@@ -29,6 +24,7 @@
              },
      },
      'Arch': {
+         'service': 'smbd',
          'client': 'smbclient',
      },
      'FreeBSD': {
@@ -45,11 +41,44 @@
         'service': salt['grains.filter_by']({
             'xenial': 'smbd',
             'trusty': 'samba',
-        }, grain='oscodename', default='xenial'),
-    },
-}, grain='os', merge=salt['pillar.get']('samba')), base='samba') %}
+         }, grain='oscodename', default='xenial'),
+      },
+    }, grain='os')
+)%}
 
-# Merge osmap onto default settings before merging pillars
-{% do defaults.samba.update(osmap) %}
+#Winbind
+{% set winbind_osmap = salt['grains.filter_by']({
+   'default':{
+      'server': 'samba-winbind',
+      'services': ['nmb', 'winbind',],
+      'utils': ['attr', 'samba-winbind-clients', 'samba-winbind-krb5-locator', 'cifs-utils', 'oddjob-mkhomedir',],
+      'libnss': 'samba-winbind-modules',
+      'pam_authconfig': '/usr/sbin/authconfig --update --enablewinbind --enablewins --enablewinbindauth'
+   },
+   'Debian': {
+      'server': 'winbind',
+      'services': ['nmbd', 'winbind',],
+      'utils': ['smbldap-tools', 'cifs-utils',],
+      'libnss': 'libnss-winbind',
+      'pam_common': {
+         'session_config': '/etc/pam.d/common-session',
+         'auth_config': '/etc/pam.d/common-auth',
+         'auth_text': ['auth  sufficient  pam_krb5.so ccache=/tmp/krb5cc_%u',
+                       'auth  sufficient  pam_unix.so likeauth nullok use_first_pass',
+                       'auth  required    pam_deny.so'],
+        },
+   },
+   'Suse':{
+      'server': 'samba-winbind',
+      'services': ['nmbd', 'winbind',],
+      'utils': ['gvfs-backend-samba', 'attr', 'smbldap-tools', 'cifs-utils',],
+     },
+  }, grain='os_family')
+%}
+
+{# start with defaults, merge osmappings, and finally pillars #}
+{% import_yaml "samba/defaults.yaml" as defaults %}
+{% do defaults.samba.update( samba_osmap ) %}
+{% do defaults.samba.winbind.update( winbind_osmap ) %}
 {% set samba = salt['pillar.get']( 'samba', default=defaults.samba, merge=True) %}
 


### PR DESCRIPTION
This PR is enhancement to expose samba configuration defaults from updated defaults.yaml (#30), with backwards compatibility/precedence retained for pillars if defined.

Winbind section is introduced for #22 RFE, and minor updates for renamed "samba_osmap".  

