### PR TITLE
Winbind: Introduce WINBIND and WINBIND-AD states

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,7 @@ Installs the samba client package.
 
 Includes the ``samba`` state.
 
-Creates a ``smb.conf`` based on pillar data.
+Creates a ``smb.conf`` based on defaults. Pillars if defined override default values.
 
 ``samba.users``
 ----------------
@@ -37,10 +37,20 @@ Includes the ``samba`` state.
 
 Creates samba users (via ``smbpasswd``)  based on pillar data.
 
+``samba.winbind``
+----------------
+
+Includes the ``samba`` state.
+
+Installs samba-winbind packages and updates NSS (nsswitch.conf).
+
+``samba.winbind-ad``
+----------------
+
+Includes the ``winbind`` state.
+
+By default this state provides full Active Directory domain membership when ``samba.role`` pillar equals ``ROLE_DOMAIN_MEMBER``.
+
 Configuration
 =============
-
-Installing the samba package will include a default ``smb.conf``. If you wish to override that config file, use the ``samba.config`` state, which creates a new ``smb.conf`` file based on pillar data.
-
-The pillar data in ``pillar.example`` results in the creation of a ``smb.conf`` similar to the packaged ``smb.conf``.
-
+The distro supplied samba package includes a default ``smb.conf`` which is overridden by ``samba.config`` state. This formula has good defaults for samba ROLE_STANDALONE and ROLE_DOMAIN_MEMBER roles, but can be extended/overridden in pillars.

--- a/pillar.example
+++ b/pillar.example
@@ -1,38 +1,22 @@
 
+## Definitions to extend and override defaults
+
 samba:
+  role: ROLE_DOMAIN_MEMBER
   conf:
     render:
+      ## List the sections your smb.conf should include
       section_order: ['global', 'homes', 'printers', 'sharename', 'user1share']
+
     sections:
       global:
-        workgroup: MYGROUP
-        server string: "Samba Server"
-        printcap name: /etc/printcap
-        load printers: yes
-        log file: "/var/log/samba/%m.log"
-        max log size: 50
-        security: user
-        dns proxy: no
-      homes:
-        comment: "Home Directories"
-        browseable: no
-        writeable: yes
-      printers:
-        comment: "All Printers"
-        path: /var/spool/samba
-        browseable: no
-        guest ok: no
-        writeable: no
-        printable: yes
-      sharename:
-        comment: "This is a shared directory"
-        browseable: yes
-        writeable: yes
-        valid users: '@sharegroup'
-        force group: sharegroup
-        create mask: '0660'
-        directory mask: '2770'
+        workgroup: EXAMPLE
+        netbios name = example
+        bind interfaces only = yes
+        interfaces = lo bond0
+
       user1share:
+        ## Optional site specific extension to smb.conf
         comment: "user1 samba share"
         path: /home/user1
         valid users: user1
@@ -41,9 +25,13 @@ samba:
         public: no
         writable: yes
         printable: no
+
   users:
+    ## Optional site specific extension to smb.conf
     user1:
       password: user1sambapassword
     user2:
       password: user2sambapassword
 
+  winbind:
+    krb5_default_realm: EXAMPLE.COM

--- a/samba/defaults.yaml
+++ b/samba/defaults.yaml
@@ -1,23 +1,117 @@
 # -*- coding: utf-8 -*-
 # vim: ft=jinja
 
+{% set default_realm=salt['pillar.get']('samba:winbind:krb5_default_realm', 'EXAMPLE.COM')%}
+{% set default_workgroup=salt['pillar.get']('samba:conf:sections:global:workgroup', 'EXAMPLE')%}
+
 # Default lookup dictionary
 samba:
+  role: ROLE_STANDALONE
   server: samba
-  client: samba
-  service: smbd
   config: /etc/samba/smb.conf
   config_src: salt://samba/files/smb.conf
+  root_group: root
 
   conf:
     render:
-      section_order: ['global']
+      #### Inherit these as smb.conf defaults.
+      section_order: ['global', 'homes', 'printers', 'sharename',]
       include_skeleton: yes
     sections:
       global:
+        ## samba.role: ROLE_STANDALONE (default)
+        workgroup: {{ default_workgroup }}
+        server string: "Samba Server %v"
+        log file: "/var/log/samba/%m.log"
+        max log size: 50
+        dns proxy: no
+        load printers: yes
+        printing: cups
+        printcap name: cups
+        security: user
+        hosts allow: 127. 10. 192.168.
+        bind interfaces only: no
+        usershare allow guests: no
+      global_role_domain_member:
+        ## samba.role: ROLE_DOMAIN_MEMBER
+        realm: {{ default_realm }}
+        security: ADS
+        allow trusted domains: no
+        client signing: yes
+        client use spnego: yes
+        encrypt passwords: yes
+        idmap config *:range: 16777216-33554431
+        kerberos method: secrets and keytab
+        template shell: /bin/bash
+        template homedir: /home/%U
+        os level: 2
+        winbind enum users: yes
+        winbind enum groups: yes
+        winbind use default domain: yes
+        winbind trusted domains only: no
+        winbind refresh tickets: yes
+        winbind offline logon: no
+        winbind cache time: 10
+        winbind nested groups: True
+        wins support: True
+        socket options: SO_KEEPALIVE IPTOS_LOWDELAY TCP_NODELAY
+        domain master: no
+        local master: no
+        preferred master: no
+        username map: /etc/samba/aduser.map
+      homes:
+        comment: "Home Directories"
+        browseable: no
+        read only: No
+        inherit acls: No
+        writeable: yes
+      printers:
+        comment: "All Printers"
+        path: /var/lib/samba/drivers
+        browseable: no
+        guest ok: yes
+        writeable: no
+        printable: yes
+        #printer admin: root, '@ntadmins', '@smbprintadm'
+      files:
+        path: /tmp/example
+        comment: "This is a shared directory"
+        browseable: yes
+        writeable: yes
+        create mask: '0660'
+        directory mask: '2770'
 
   users:
 
   preinstall:
     cmd:
     osreleases: []
+
+  winbind:
+    krb5_default_realm: {{ default_realm }}
+    pam_mkhomedir_src: salt://samba/files/mkhomedir
+    usermap: /etc/samba/aduser.map
+    usermap_src: salt://samba/files/aduser.map
+
+    pam_winbind:
+      config: /etc/security/pam_winbind.conf
+      config_src: salt://samba/files/pam_winbind.conf
+      global:
+        debug: no
+        debug_state: no
+        cached_login: no
+        krb5_auth: yes
+        krb5_ccache_type: FILE
+        require_membership_of:
+        warn_pwd_expire: 14
+        silent: no
+        mkhomedir: yes
+
+    nsswitch:
+      regex:
+       {% raw %}
+        - ['hostsMdns', '^(?!#).*(?<!#|\w)(host.*:.*files\s)(mdns4?_minimal.*\]\s*)(dns.*$)', '\1 \3',]
+        - ['passwd', '^(?!#).*(?<!#|\w)(passwd.*:.*(files|compat))(?!.*winbind)(.*$)(?<!winbind)', '\1 winbind \3',]
+        - ['group', '^(?!#|net).*(?<!#|\w)(group.*:.*(files|compat))(?!.*winbind)(.*$)(?<!winbind)', '\1 winbind \3',]
+        - ['hostsWins', '^(?!#).*(?<!#|\w)(host.*:.*files\s)(?!.*wins)(.*$)(?<!wins)', '\1wins \2',]
+       {% endraw %}

--- a/samba/files/aduser.map
+++ b/samba/files/aduser.map
@@ -1,0 +1,1 @@
+!root = {{ workgroup }}\Administrator

--- a/samba/files/mkhomedir
+++ b/samba/files/mkhomedir
@@ -1,0 +1,7 @@
+Name: Create home directory on login
+Default: yes
+Priority: 1
+Session-Type: Additional
+Session-Interactive-Only: yes
+Session:
+        required pam_mkhomedir.so umask=0077 skel=/etc/skel

--- a/samba/files/pam_winbind.conf
+++ b/samba/files/pam_winbind.conf
@@ -1,0 +1,90 @@
+{% raw %}
+#######################################################################
+# This file is managed by salt. Manual changes risk being overwritten. 
+# The contents of an example skeleton pam_winbind.conf are stored 
+# at the bottom as a quick reference.                                         
+#######################################################################
+{% endraw %}
+
+{%- macro makeoutput(outdict) -%}
+  {%- for key, value in outdict|dictsort -%}
+  {{ output(key, value) }}
+  {%- endfor %}
+{%- endmacro -%}
+
+{%- macro output(key, value, spaces=0) -%}
+  {%- set shift = spaces * " " %}
+  {%- set newline = "\n" -%}
+  {%- if value is mapping %}
+    {{ shift }}{{ key }} = {
+    {%- for key, value in value|dictsort -%}
+    {{ output(key, value, spaces=spaces+4) }}
+    {%- endfor %}
+    {{ shift }}}
+  {%- elif key == '#' -%}
+    {{ newline }}{{ key }} {{ value }}
+  {%- elif value is string or value is number %}
+    {{ shift }}{{ key }} = {{ value }}
+  {%- elif value -%}
+    {%- for value in value -%}
+    {{ output(key, value, spaces=spaces) }}
+    {%- endfor %}
+  {%- endif %}
+{%- endmacro -%}
+
+{%- macro comment(str) -%}
+  {{ output("#", str) }}
+{%- endmacro -%}
+
+{% from "samba/map.jinja" import samba with context %}
+
+[global]
+  {%- set pam_wbind_defaults = samba.winbind.pam_winbind.get('global', {}) -%}
+  {{ makeoutput(pam_wbind_defaults) if pam_wbind_defaults else comment('Using software defaults') }}
+
+#
+# skeleton pam_winbind.conf for reference
+#
+# This pam_winbind.conf can be used to set various options for the
+# pam_winbind(8) PAM module. Alternatively setting these Options
+# in the PAM configuration is allowed and takes precedence.
+# There is only one section (global).
+#
+# pam_winbind configuration file
+#
+# /etc/security/pam_winbind.conf
+#
+
+#====================== global ==============================
+;[global]
+; debug = no
+# Debugging output for pam_winbind to syslog. Default "no".
+
+# turn on extended PAM state debugging
+;debug_state = no
+
+# request a cached login if possible
+# (needs "winbind offline logon = yes" in smb.conf)
+;cached_login = no
+
+# authenticate using kerberos
+;krb5_auth = no
+
+# when using kerberos, request a "FILE" krb5 credential cache type
+# (leave empty to just do krb5 authentication but not have a ticket
+# afterwards)
+;krb5_ccache_type =
+
+# make successful authentication dependend on membership of one SID
+# (can also take a name); commas, no spaces.
+;require_membership_of =
+
+# password expiry warning period in days
+;warn_pwd_expire = 14
+
+# omit pam conversations
+;silent = no
+
+# create homedirectory on the fly
+;mkhomedir = no
+

--- a/samba/files/smb.conf
+++ b/samba/files/smb.conf
@@ -1,31 +1,44 @@
-{%- set samba_sections = salt['pillar.get']('samba:conf:sections', {}) %}
-{%- set conf_generator_settings = salt['pillar.get']('samba:conf:render', {}) %}
+#######################################################################
+# This file is managed by salt. Manual changes risk being overwritten.
+# The contents of an example skeleton smb.conf are stored at the
+# bottom as a quick reference. See also smb.conf(5).
+#######################################################################
+{% from "samba/map.jinja" import samba with context %}
 
+{# Samba role handling #}
+{%- if samba.winbind.krb5_default_realm -%}
+   {% import_yaml "samba/defaults.yaml" as defs %}
+   {% if samba.role == 'ROLE_DOMAIN_MEMBER' %}
+      {% do defs.samba.conf.sections.global.update( defs.samba.conf.sections.global_role_domain_member ) %}
+      {% do samba.conf.sections.global.update( salt['pillar.get']('samba:conf:sections:global',
+                                            default=defs.samba.conf.sections.global, merge=True)) %}
+   {% endif %}
+{% endif %}
+
+{# Build smb.conf #}
 {%- macro config_section(section) %}
-{%- set options = samba_sections.get(section, {}) -%}
+{%- set options = samba.conf.sections.get(section, {}) -%}
+  {% if section not in ('global_role_domain_member', 'some_other_scenario', ) %}
 [{{ section }}]
-    {%- for option, value in options.items() %}
-    {{ option }} = {{ value }}
-    {%- endfor %}
+    {% if options %}
+      {%- for option, value in options.items() %}
+      {{ option }} = {{ value }}
+      {%- endfor %}
+    {% endif %}
+  {% endif %}
 {%- endmacro -%}
 
-#
-# This file is managed by salt. Manual changes risk being overwritten.
-# If so configured, the contents of the original skeleton smb.conf are stored
-# at the bottom as a quick reference to the default option values.
-#
-{%- set ordered_sections = conf_generator_settings.get('section_order', []) %}
-{%- for k in ordered_sections %}
+{%- set ordered_sections = samba.conf.render.get('section_order', {}) %}
+{%- for k in ordered_sections or None %}
 {{ config_section(k) }}
 {%- endfor -%}
-{%- for k in samba_sections.keys() %}
+{%- for k in samba.conf.sections.keys() %}
     {%- if k not in ordered_sections %}
 {{ config_section(k) }}
     {%- endif %}
 {%- endfor -%}
 
-{%- if conf_generator_settings.get('include_skeleton', True) %}
-
+{%- if samba.conf.render.get('include_skeleton', True) %}
 # This is the main Samba configuration file. You should read the
 # smb.conf(5) manual page in order to understand the options listed
 # here. Samba has a huge number of configurable options (perhaps too

--- a/samba/map.jinja
+++ b/samba/map.jinja
@@ -2,10 +2,11 @@
 # vim: ft=jinja
 # OS family parameters overriding defaults
 
-{## start with defaults from defaults.yaml ##}
-{% import_yaml "samba/defaults.yaml" as defaults %}
-
-{% set osmap = salt['grains.filter_by']({
+{% set samba_osmap = salt['grains.filter_by']({
+    'default':{
+        'client': 'samba-client',
+        'service': 'smb',
+        },
     'Debian': {
         'client': 'samba-client',
         'service': salt['grains.filter_by']({
@@ -13,12 +14,6 @@
 	    'squeeze': 'samba',
 	    'wheezy': 'samba',
 	}, grain='oscodename', default='lenny'),
-     },
-     'RedHat': {
-         'service': 'smb',
-     },
-     'CentOS': {
-         'service': 'smb',
      },
      'Suse':{
           'service': 'smb',
@@ -29,6 +24,7 @@
              },
      },
      'Arch': {
+         'service': 'smbd',
          'client': 'smbclient',
      },
      'FreeBSD': {
@@ -45,11 +41,47 @@
         'service': salt['grains.filter_by']({
             'xenial': 'smbd',
             'trusty': 'samba',
-        }, grain='oscodename', default='xenial'),
-    },
-}, grain='os', merge=salt['pillar.get']('samba')), base='samba') %}
+         }, grain='oscodename', default='xenial'),
+      },
+    }, grain='os')
+)%}
 
-# Merge osmap onto default settings before merging pillars
-{% do defaults.samba.update(osmap) %}
+#Winbind
+{% set winbind_osmap = salt['grains.filter_by']({
+   'default':{
+      'server': 'samba-winbind',
+      'services': ['nmb', 'winbind',],
+      'utils': ['attr', 'samba-winbind-clients', 'samba-winbind-krb5-locator', 'cifs-utils', 'oddjob-mkhomedir',],
+      'libnss': 'samba-winbind-modules',
+      'pam_authconfig': '/usr/sbin/authconfig --update --enablewinbind --enablewins --enablemkhomedir --enablewinbindauth',
+      'pam_authconfig_cmd': '/usr/sbin/authconfig',
+   },
+   'Debian': {
+      'server': 'winbind',
+      'services': ['nmbd', 'winbind',],
+      'utils': ['libpam-winbind', 'smbldap-tools', 'cifs-utils',],
+      'libnss': 'libnss-winbind',
+      'pam_seen': '/var/lib/pam/seen',
+      'pam_mkhomedir': '/usr/share/pam-configs/mkhomedir',
+      'pam_authconfig': 'DEBIAN_FRONTEND=noninteractive /usr/sbin/pam-auth-update',
+      'pam_authconfig_cmd': '/usr/sbin/pam-auth-update',
+   },
+   'Suse':{
+      'server': 'samba-winbind',
+      'libnss': '',
+      'services': ['nmb', 'winbind',],
+      'utils': ['gvfs-backend-samba', 'attr', 'cifs-utils',],
+   },
+ }, grain='os_family', merge=salt['grains.filter_by']({
+    'Fedora': {
+      'pam_authconfig': '/usr/sbin/authconfig --update --enablewinbind --enablemkhomedir --enablewinbindauth --disablesssd --disablesssdauth',
+     },
+   }, grain='os')
+)%}
+
+{# start with defaults, merge osmappings, and finally pillars #}
+{% import_yaml "samba/defaults.yaml" as defaults %}
+{% do defaults.samba.update( samba_osmap ) %}
+{% do defaults.samba.winbind.update( winbind_osmap ) %}
 {% set samba = salt['pillar.get']( 'samba', default=defaults.samba, merge=True) %}
 

--- a/samba/winbind-ad.sls
+++ b/samba/winbind-ad.sls
@@ -1,0 +1,72 @@
+{% from "samba/map.jinja" import samba with context %}
+
+include:
+  - samba.winbind
+
+  {% if grains.os_family in ('Debian',) %}
+
+samba_winbind_pam_mkhomedir:
+  file.managed:
+    - name: {{ samba.winbind.pam_mkhomedir }}
+    - source: {{ samba.winbind.pam_mkhomedir_src }}
+    - template: jinja
+    - create: True
+    - require:
+      - pkg: samba_winbind_software
+    
+    {% for pam_config in ['winbind', 'mkhomedir',] %}
+samba_winbind_pamforget_{{ pam_config }}:
+  file.line:
+    - name: {{ samba.winbind.pam_seen }}
+    - match: {{ pam_config }}
+    - mode: delete
+    - require:
+      - file: samba_winbind_pam_mkhomedir
+    - require_in:
+      - cmd: samba_winbind_ad_authconfig
+
+    {% endfor %}
+    {% for config in samba.winbind.nsswitch.regex %}
+
+samba_winbind_nsswitch_{{ config[0] }}:
+  file.replace:
+    - name: /etc/nsswitch.conf
+    - pattern: {{ config[1] }}
+    - repl: {{ config[2] }}
+    - backup: '.salt.bak'
+    - require:
+      - pkg: samba_winbind_software
+    - require_in:
+      - cmd: samba_winbind_ad_authconfig
+
+    {% endfor %}
+  {% endif %}
+
+  {% if grains.os_family in ('RedHat', 'Debian') %}
+
+samba_winbind_ad_authconfig:
+  cmd.run:
+    - name: {{ samba.winbind.pam_authconfig }}
+    - onlyif: test -f {{ samba.winbind.pam_authconfig_cmd }}
+    - watch_in:
+      - service: samba_winbind_services
+
+  {% else %}
+
+     # todo: pam solution for other distros ...
+
+  {% endif %}
+
+  {% if samba.winbind.usermap %}
+samba_winbind_ad_usermap:
+  file.managed:
+    - name: {{ samba.winbind.usermap }}
+    - source: {{ samba.winbind.usermap_src }}
+    - mode: 755
+    - create: True
+    - template: jinja
+    - context:
+      workgroup: {{ samba.conf.sections.global.workgroup }}
+    - require:
+      - pkg: samba_winbind_software
+  {% endif %}    

--- a/samba/winbind.sls
+++ b/samba/winbind.sls
@@ -1,0 +1,40 @@
+{% from "samba/map.jinja" import samba with context %}
+
+samba_winbind_software:
+  pkg.installed:
+    - names:
+      - {{ samba.winbind.server }}
+      {% if samba.winbind.libnss %}
+      - {{ samba.winbind.libnss }}
+      {% endif %}
+      {% for pkg in samba.winbind.utils %}
+      - {{ pkg }}
+      {% endfor %}
+    - require_in:
+      - file: samba_winbind_software
+  file.managed:
+    - name: {{ samba.winbind.pam_winbind.config }}
+    - source: {{ samba.winbind.pam_winbind.config_src }}
+    - template: jinja
+    - user: root
+    - group: {{ samba.get('root_group', 'root') }}
+    - mode: 0644
+    - require_in:
+      - service: samba_winbind_software
+  service.enabled:
+    - names:
+      {% for service in samba.winbind.services %}
+      -  {{ service }}
+      {% endfor %}
+    - require_in:
+      - samba_winbind_services
+
+samba_winbind_services:
+  service.running:
+    - unmask_runtime: true
+    - names:
+      - {{ samba.service }}
+      {% for service in samba.winbind.services %}
+      -  {{ service }}
+      {% endfor %}
+


### PR DESCRIPTION
This PR introduces support for RFE #22, introducing and documenting Winbind features.  See log demonstrating the feature on ubuntu (minor issues in log fixed in updated commit).  Formula now supports Samba ROLE_STANDALONE and ROLE_DOMAIN_MEMBER roles (Ubuntu and Centos7).

Ubuntu Log: [ubuntu_smb_winbind.log.txt](https://github.com/saltstack-formulas/samba-formula/files/1516186/ubuntu_smb_winbind.log.txt)
Centos Log: [centos_winbindAD.log.txt](https://github.com/saltstack-formulas/samba-formula/files/1553417/centos_winbindAD.log.txt)   (Note: failure to start winbind service is expected and documented behaviour - we need to join a domain before winbind will start).

After executing `samba.winbind-ad` state, AD integration is three commands ...

```
[posixuser@centos73 ~]$ sudo net ads join EXAMPLE.COM -U domainadm
Enter domainadm's password:
Using short domain name -- EXAMPLE
Joined 'centos73' to dns domain 'example.com'
[posixuser@centos73 ~]$ sudo kinit -k centos73\$@EXAMPLE.COM
[posixuser@centos73 ~]$ sudo systemctl restart winbind
 
laptop: messi$ ssh domainadm@centos73.example.com
domainadm@centos73.example.com's password: 
Kickstarted on 2017-12-11
```

