### PR TITLE
Suse AD authentication

### DIFF
--- a/samba/map.jinja
+++ b/samba/map.jinja
@@ -73,6 +73,8 @@
       'libnss': '',
       'services': ['nmb', 'winbind',],
       'utils': ['gvfs-backend-samba', 'attr', 'cifs-utils',],
+      'pam_authconfig': '/usr/sbin/pam-config -a --winbind --mkhomedir --mkhomedir-umask=0077 --mkhomedir-skel=/etc/skel',
+      'pam_authconfig_cmd': '/usr/sbin/pam-config',
    },
  }, grain='os_family', merge=salt['grains.filter_by']({
     'Fedora': {

--- a/samba/winbind-ad.sls
+++ b/samba/winbind-ad.sls
@@ -26,6 +26,10 @@ samba_winbind_pamforget_{{ pam_config }}:
       - cmd: samba_winbind_ad_authconfig
 
     {% endfor %}
+{% endif %}
+
+  {% if grains.os_family in ('Debian', 'Suse',) %}
+
     {% for config in samba.winbind.nsswitch.regex %}
 
 samba_winbind_nsswitch_{{ config[0] }}:
@@ -42,7 +46,7 @@ samba_winbind_nsswitch_{{ config[0] }}:
     {% endfor %}
   {% endif %}
 
-  {% if grains.os_family in ('RedHat', 'Debian') %}
+  {% if grains.os_family in ('RedHat', 'Debian', 'Suse',) %}
 
 samba_winbind_ad_authconfig:
   cmd.run:


### PR DESCRIPTION
This PR enables AD authentication on Suse in the  `samba.winbind-ad` state.

```
          ID: samba_winbind_nsswitch_hostsMdns
    Function: file.replace
        Name: /etc/nsswitch.conf
      Result: True
     Comment: Changes were made
     Started: 13:34:34.779544
    Duration: 4.8 ms
     Changes:   
              ----------
              diff:
                  --- 
                  +++ 
                  @@ -29,7 +29,7 @@
                   passwd: compat
                   group:  compat
                   
                  -hosts:  	files mdns_minimal [NOTFOUND=return] dns
                  +hosts:  	files  dns
                   networks:	files dns
                   
                   services:	files
----------
          ID: samba_winbind_nsswitch_passwd
    Function: file.replace
        Name: /etc/nsswitch.conf
      Result: True
     Comment: Changes were made
     Started: 13:34:34.784643
    Duration: 2.676 ms
     Changes:   
              ----------
              diff:
                  --- 
                  +++ 
                  @@ -26,7 +26,7 @@
                   # shadow: files nis
                   # group:  files nis
                   
                  -passwd: compat
                  +passwd: compat winbind 
                   group:  compat
                   
                   hosts:  	files  dns
----------
          ID: samba_winbind_nsswitch_group
    Function: file.replace
        Name: /etc/nsswitch.conf
      Result: True
     Comment: Changes were made
     Started: 13:34:34.787613
    Duration: 2.434 ms
     Changes:   
              ----------
              diff:
                  --- 
                  +++ 
                  @@ -27,7 +27,7 @@
                   # group:  files nis
                   
                   passwd: compat winbind 
                  -group:  compat
                  +group:  compat winbind 
                   
                   hosts:  	files  dns
                   networks:	files dns
----------
          ID: samba_winbind_nsswitch_hostsWins
    Function: file.replace
        Name: /etc/nsswitch.conf
      Result: True
     Comment: Changes were made
     Started: 13:34:34.790310
    Duration: 2.221 ms
     Changes:   
              ----------
              diff:
                  --- 
                  +++ 
                  @@ -29,7 +29,7 @@
                   passwd: compat winbind 
                   group:  compat winbind 
                   
                  -hosts:  	files  dns
                  +hosts:  	files wins  dns
                   networks:	files dns
                   
                   services:	files
----------
          ID: samba_winbind_ad_authconfig
    Function: cmd.run
        Name: /usr/sbin/pam-config -a --winbind --mkhomedir --mkhomedir-umask=0077 --mkhomedir-skel=/etc/skel
      Result: True
     Comment: Command "/usr/sbin/pam-config -a --winbind --mkhomedir --mkhomedir-umask=0077 --mkhomedir-skel=/etc/skel" run
     Started: 13:34:34.792920
    Duration: 14.74 ms
     Changes:   
              ----------
              pid:
                  3928
              retcode:
                  0
              stderr:
              stdout:
----------
          ID: samba_winbind_services
    Function: service.running
        Name: smb
      Result: True
     Comment: Service restarted
     Started: 13:34:34.821158
    Duration: 2757.222 ms
```