### PR TITLE
Better handling of default sections

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -7,6 +7,7 @@ samba:
     render:
       ## List the sections your smb.conf should include
       section_order: ['global', 'homes', 'printers', 'sharename', 'user1share']
+      include_unordered_sections: yes
 
     sections:
       global:

--- a/samba/defaults.yaml
+++ b/samba/defaults.yaml
@@ -74,13 +74,6 @@ samba:
         writeable: no
         printable: yes
         #printer admin: root, '@ntadmins', '@smbprintadm'
-      files:
-        path: /tmp/example
-        comment: "This is a shared directory"
-        browseable: yes
-        writeable: yes
-        create mask: '0660'
-        directory mask: '2770'
 
   users:
 

--- a/samba/defaults.yaml
+++ b/samba/defaults.yaml
@@ -17,6 +17,7 @@ samba:
       #### Inherit these as smb.conf defaults.
       section_order: ['global', 'homes', 'printers', 'sharename',]
       include_skeleton: yes
+      include_unordered_sections: yes
     sections:
       global:
         ## samba.role: ROLE_STANDALONE (default)

--- a/samba/files/smb.conf
+++ b/samba/files/smb.conf
@@ -32,11 +32,13 @@
 {%- for k in ordered_sections or None %}
 {{ config_section(k) }}
 {%- endfor -%}
+{%- if samba.conf.render.get('include_unordered_sections', True) -%}
 {%- for k in samba.conf.sections.keys()|sort %}
     {%- if k not in ordered_sections %}
 {{ config_section(k) }}
     {%- endif %}
 {%- endfor -%}
+{%- endif -%}
 
 {%- if samba.conf.render.get('include_skeleton', True) %}
 # This is the main Samba configuration file. You should read the


### PR DESCRIPTION
This pull request adds a way to disable the default sections defined in samba/defaults.yaml and it drops the default "files" section which seems to be a misplaced example entry. "homes" and "printers" sections are real default sections however.