### PR TITLE
Fix idmap config 'schema_mode' syntax in yaml

### DIFF
--- a/samba/defaults.yaml
+++ b/samba/defaults.yaml
@@ -42,9 +42,9 @@ samba:
         client use spnego: yes
         encrypt passwords: yes
         # idmap config for this domain
-        idmap config *:range: 16777216-33554431
-        #idmap config *:backend = ad
-        #idmap config *:schema_mode = rfc2307
+        "idmap config * : range": 16777216-33554431
+        #"idmap config * : backend": ad
+        "idmap config * : schema_mode": rfc2307
         kerberos method: secrets and keytab
         template shell: /bin/bash
         template homedir: /home/%U


### PR DESCRIPTION
Fix for issue https://github.com/saltstack-formulas/samba-formula/issues/44