### PR TITLE
Stop AD user accounts getting locked

### DIFF
--- a/samba/defaults.yaml
+++ b/samba/defaults.yaml
@@ -54,7 +54,7 @@ samba:
         winbind expand groups: 0
         winbind use default domain: yes
         winbind trusted domains only: no
-        winbind refresh tickets: yes
+        winbind refresh tickets: no
         winbind offline logon: no
         winbind cache time: 10
         winbind nested groups: True


### PR DESCRIPTION
This PR is to stop my AD account getting locked ;-)

After successfully changing an AD users password (in AD) the users account (in AD) will eventually get locked.  The solution is described herer: https://www.suse.com/support/kb/doc/?id=7017990)

