### PR TITLE
Replaced equal sign with colon

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -12,9 +12,9 @@ samba:
     sections:
       global:
         workgroup: EXAMPLE
-        netbios name = example
-        bind interfaces only = yes
-        interfaces = lo bond0
+        netbios name: example
+        bind interfaces only: yes
+        interfaces: lo bond0
 
       user1share:
         ## Optional site specific extension to smb.conf


### PR DESCRIPTION
I'm currently experimenting with salt, and had troubles using the pillar.exmaple of this formula because of the equal sign. Excerpt from log:
```
    "could not find expected ':'", self.get_mark())
yaml.scanner.ScannerError: while scanning a simple key
  in "<unicode string>", line 12, column 9:
            bind interfaces only = yes
            ^
could not find expected ':'
  in "<unicode string>", line 13, column 9:
            interfaces = eth0
            ^

```