### PR TITLE
Make winbind services changes optional

### DIFF
--- a/samba/winbind-ad.sls
+++ b/samba/winbind-ad.sls
@@ -12,7 +12,7 @@ samba_winbind_pam_mkhomedir:
     - template: jinja
     - create: True
     - require:
-      - pkg: samba_winbind_software
+      - pkg: samba_winbind_services
     
     {% for pam_config in ['winbind', 'mkhomedir',] %}
 samba_winbind_pamforget_{{ pam_config }}:
@@ -39,7 +39,7 @@ samba_winbind_nsswitch_{{ config[0] }}:
     - repl: {{ config[2] }}
     - backup: '.salt.bak'
     - require:
-      - pkg: samba_winbind_software
+      - pkg: samba_winbind_services
     - require_in:
       - cmd: samba_winbind_ad_authconfig
 
@@ -72,5 +72,5 @@ samba_winbind_ad_usermap:
     - context:
       workgroup: {{ samba.conf.sections.global.workgroup }}
     - require:
-      - pkg: samba_winbind_software
+      - pkg: samba_winbind_services
   {% endif %}    

--- a/samba/winbind.sls
+++ b/samba/winbind.sls
@@ -1,5 +1,6 @@
 {% from "samba/map.jinja" import samba with context %}
 
+## Note: If pkg.installed fails try removing `libnss` and `libpam` first.
 samba_winbind_services:
   pkg.installed:
     - names:


### PR DESCRIPTION
This PR is to address #49.  

Four configurable boolean values are introduced to allow for controlled execution of the `winbind-ad` state.  Default is True (winbind will restart) but behaviour is now tunable (False).