### PR TITLE
Ensure winbind package is installed before libs

### DIFF
--- a/samba/winbind.sls
+++ b/samba/winbind.sls
@@ -2,6 +2,13 @@
 
 samba_winbind_software:
   pkg.installed:
+    - name: {{ samba.winbind.server }}
+    - refresh: True
+    - require_in:
+      - pkg: samba_winbind_services
+
+samba_winbind_services:
+  pkg.installed:
     - names:
       - {{ samba.winbind.server }}
       {% if samba.winbind.libnss %}
@@ -18,23 +25,14 @@ samba_winbind_software:
     - template: jinja
     - user: root
     - group: {{ samba.get('root_group', 'root') }}
-    - mode: 0644
+    - mode: '0644'
     - require_in:
       - service: samba_winbind_software
-  service.enabled:
-    - names:
-      {% for service in samba.winbind.services %}
-      -  {{ service }}
-      {% endfor %}
-    - require_in:
-      - samba_winbind_services
-
-samba_winbind_services:
   service.running:
     - unmask_runtime: true
     - names:
-      - {{ samba.service }}
       {% for service in samba.winbind.services %}
       -  {{ service }}
       {% endfor %}
-
+      - {{ samba.service }}
+    - enable: True


### PR DESCRIPTION
This PR is to fix dependency issue seen on Ubuntu 18.04.

Some libraries need `winbind` package installed & configured first or apt breaks.
```
Feb 12 10:25:19 iedx1 systemd[1]: Failed to start Samba Winbind Daemon.
dpkg: error processing package winbind (--configure):
 installed winbind package post-installation script subprocess returned error exit status 1
dpkg: dependency problems prevent configuration of libpam-winbind:amd64:
 libpam-winbind:amd64 depends on winbind (= 2:4.7.6+dfsg~ubuntu-0ubuntu2.6); however:
  Package winbind is not configured yet.

dpkg: error processing package libpam-winbind:amd64 (--configure):
 dependency problems - leaving unconfigured
dpkg: dependency problems prevent configuration of libnss-winbind:amd64:
 libnss-winbind:amd64 depends on winbind (= 2:4.7.6+dfsg~ubuntu-0ubuntu2.6); however:
  Package winbind is not configured yet.

dpkg: error processing package libnss-winbind:amd64 (--configure):
 dependency problems - leaving unconfigured
```

I also merged the `service.enabled` and `service.running` states.