### PR TITLE
Fix pkg.installed not removing 'winbind' packages

### DIFF
--- a/samba/winbind/clean.sls
+++ b/samba/winbind/clean.sls
@@ -10,7 +10,7 @@ samba_winbind_services_clean:
     - enable: False
   file.absent:
     - name: {{ samba.winbind.pam_winbind.config }}
-  pkg.removed:
+  pkg.purged:
     - names:
       {% if samba.winbind.libnss %}
       - {{ samba.winbind.libnss }}
@@ -18,6 +18,7 @@ samba_winbind_services_clean:
       {% for pkg in samba.winbind.utils %}
       - {{ pkg }}
       {% endfor %}
+      - libwbclient0       ###needed (on ubuntu) to purge winbind (avoiding https://github.com/saltstack/salt/issues/42306)
       - {{ samba.winbind.server }}
     - require:
       - file: samba_winbind_services_clean

--- a/samba/winbind/clean.sls
+++ b/samba/winbind/clean.sls
@@ -20,5 +20,6 @@ samba_winbind_services_clean:
       {% endfor %}
       - libwbclient0       ###needed (on ubuntu) to purge winbind (avoiding https://github.com/saltstack/salt/issues/42306)
       - {{ samba.winbind.server }}
+    - normalize: True
     - require:
       - file: samba_winbind_services_clean


### PR DESCRIPTION
On Ubuntu 18.04 both `dpkg/apt` and salt `clean.sls` do not remove/purge 'winbind' packages. 

The behaviour was similar to  https://github.com/saltstack/salt/issues/42306  but troubleshooting suggests some glitch in Ubuntu package manager or samba/winbind packaging.   

- Changing `pkg.removed` to `pkg.purged` had no effect (but no harm adding to PR)
- Explicitly removing `libwbclient0` package resolved the problem.

This PR ensures `winbind` packages are actually removed as claimed by `apt/dpkg` & `salt`.