### PR TITLE
fix(init): don't run users state by default

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ Available states
 ``samba``
 ---------
 
-Installs the samba server package and service.
+Installs the samba server and client packages and starts the samba service.
 
 ``samba.client``
 ----------------

--- a/samba/clean.sls
+++ b/samba/clean.sls
@@ -2,7 +2,7 @@
 include:
   - samba.winbind-ad.clean      ##because it depends on samba service
   - samba.winbind.clean         ##because it depends on samba service
-  - samba.users.clean
+  - samba.users.clean           ##because it depends on samba service
   - samba.client.clean
   - samba.config.clean
   - samba.server.clean

--- a/samba/init.sls
+++ b/samba/init.sls
@@ -3,6 +3,6 @@ include:
   - samba.server
   - samba.config
   - samba.client
-  - samba.users
+  # samba.users
   # samba.winbind
   # samba.winbind-ad


### PR DESCRIPTION
According to README the `users` state should not be part of `init` state.  It should only be run when you have users to manage.  This PR fixes that.