### PR TITLE
Pdbedit #35 & #68

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -38,8 +38,8 @@ samba:
         nt: EB11C288046508EBE2AA213DB0860813 ## Equals "user1sambapassword" in plaintext
     user2:
       password: 
-        passwd: $1$Kvm5/Q6Y$B19DYyLRCqeUsyacipVet1 #Equals "user2sambapassword" in Plaintext
-        nt: 5AA13065E0B8A81835D48291E5C47236 #Equals "user2sambapassword" in Plaintext
+        passwd: $1$Kvm5/Q6Y$B19DYyLRCqeUsyacipVet1 ## Equals "user2sambapassword" in Plaintext
+        nt: 5AA13065E0B8A81835D48291E5C47236 ## Equals "user2sambapassword" in Plaintext
 
   winbind:
     krb5_default_realm: EXAMPLE.COM

--- a/pillar.example
+++ b/pillar.example
@@ -30,10 +30,16 @@ samba:
 
   users:
     ## Optional site specific extension to smb.conf
+    ## user.present passwd needs hash, generate it with the following command -> openssl passwd -1
+    ## pdbedit.managed nt needs hash, generate it with the following command -> salt '*' pdbedit.generate_nt_hash PASSWORD
     user1:
-      password: user1sambapassword
+      password:
+        passwd: $1$vFH3.Plc$7CZnr18jaLx1fMBGm1NMP/ ## Equals "user1sambapassword" in plaintext
+        nt: EB11C288046508EBE2AA213DB0860813 ## Equals "user1sambapassword" in plaintext
     user2:
-      password: user2sambapassword
+      password: 
+        passwd: $1$Kvm5/Q6Y$B19DYyLRCqeUsyacipVet1 #Equals "user2sambapassword" in Plaintext
+        nt: 5AA13065E0B8A81835D48291E5C47236 #Equals "user2sambapassword" in Plaintext
 
   winbind:
     krb5_default_realm: EXAMPLE.COM

--- a/pillar.example
+++ b/pillar.example
@@ -30,8 +30,8 @@ samba:
 
   users:
     ## Optional site specific extension to smb.conf
-    ## user.present passwd needs hash, generate it with the following command -> openssl passwd -1
-    ## pdbedit.managed nt needs hash, generate it with the following command -> salt '*' pdbedit.generate_nt_hash PASSWORD
+    ## user.present passwd needs plaintext or hash. Hash is recommended, generate it with the following command -> openssl passwd -1
+    ## pdbedit.managed nt needs hash. Plaintext seem to be broken (https://github.com/saltstack-formulas/samba-formula/issues/35). Generate it with the following command -> salt '*' pdbedit.generate_nt_hash PASSWORD
     user1:
       password:
         passwd: $1$vFH3.Plc$7CZnr18jaLx1fMBGm1NMP/ ## Equals "user1sambapassword" in plaintext

--- a/samba/users/init.sls
+++ b/samba/users/init.sls
@@ -4,13 +4,13 @@ include:
 {% endif %}
 
 {% for login,user in salt['pillar.get']('samba:users', {}).items() %}
-samba_{{ login }}:
+{{ login }}:
   user.present:
     - name: {{ login }}
     - fullname: {{ login }}
-    - password: {{ user.password }}
-
-samba_smbpasswd_{{ login }}:
-  cmd.run:
-    - name: "(echo '{{ user.password }}'; echo '{{ user.password }}') | smbpasswd -as {{ login }}"
+    - password: {{ user.password.passwd }}
+  pdbedit.managed:
+    - login: {{ login }}
+    - password: {{ user.password.nt }}
+    - password_hashed: True
 {% endfor %}


### PR DESCRIPTION
This is a fix for issue #35 & #68 
This is a breaking change in my opinion, but seems like the way to go.
It replaces `cmd.run` with `pbedit.managed`. As pbedit plaintext doesn't work for me (read #35), I had to switch to hashes. Sadly `user.managed` and `pbedit.managed` use different hashes, hence requiring two hashes in the pillar example. I updated it accordingly.
Please ask any questions if necessary.