### PR TITLE
Fix for issue #67: "virtual package" name: samba-client -> smbclient (Debian)

### DIFF
--- a/samba/map.jinja
+++ b/samba/map.jinja
@@ -8,7 +8,7 @@
         'service': 'smb',
     },
     'Debian': {
-        'client': 'samba-client',
+        'client': 'smbclient',
         'service': salt['grains.filter_by']({
             'lenny': 'samba',
             'squeeze': 'samba',


### PR DESCRIPTION
Replace "samba-client" with "smbclient" according to https://packages.debian.org/de/buster/smbclient