### PR TITLE
Add Debian bookworm support in map.jinja

### DIFF
--- a/samba/map.jinja
+++ b/samba/map.jinja
@@ -15,7 +15,8 @@
             'wheezy': 'samba',
             'jessie': 'smbd',
             'stretch': 'smbd',
-            'buster': 'smbd'
+            'buster': 'smbd',
+            'bullseye': 'smbd'
         }, grain='oscodename', default='lenny'),
     },
     'Suse':{

--- a/samba/map.jinja
+++ b/samba/map.jinja
@@ -16,7 +16,8 @@
             'jessie': 'smbd',
             'stretch': 'smbd',
             'buster': 'smbd',
-            'bullseye': 'smbd'
+            'bullseye': 'smbd',
+            'bookworm': 'smbd'
         }, grain='oscodename', default='lenny'),
     },
     'Suse':{


### PR DESCRIPTION
## Summary

This PR adds explicit support for Debian 12 "bookworm" by mapping it to `smbd` in the `map.jinja` file.

## Rationale

The `smbd` service name remains consistent from Debian Jessie through Bookworm. This update ensures correct behavior when using grains like `oscodename` to configure Samba on Bookworm-based systems.

## Notes

Tested on a local Salt master with Debian 12 minions. No impact on other distros.